### PR TITLE
We only play with GC

### DIFF
--- a/rules/game_process.tex
+++ b/rules/game_process.tex
@@ -154,7 +154,7 @@ Robots are brought into the \texttt{initial} state after they are placed. Once t
 
 \subsection{Kick-off}
 \label{sec:kick-off}
-For kick-off, the robots listening wirelessly to the GameController run through three states: \texttt{ready}, \texttt{set}, and \texttt{playing}.
+For kick-off, the robots run through three states: \texttt{ready}, \texttt{set}, and \texttt{playing}.
 
 In the \texttt{ready} state, the robots must walk to legal kick-off positions for their team.
 


### PR DESCRIPTION
This PR should not delay the release of the rules.

In earlier sections of the rules its already stated that we only play with GC. We don't need special handling for chestbutton control anymore. So we can remove this.

Please discuss.