### PR TITLE
Limit the rate of GameController return packets

### DIFF
--- a/rules/app_changes.tex
+++ b/rules/app_changes.tex
@@ -13,6 +13,7 @@ This is a brief non-normative list of rule changes from \LastRCYear to \RCYear.
     \item \textbf{The goalkeeper isn't required to use jersey number 1 anymore} (\cf~\cref{sec:goalkeeper}).
   \end{itemize}
   \item The maximum number of data bytes in the \texttt{SPLStandardMessage} has been reduced from 474 to \TeamMessageDataSize{} (\cf~\cref{sec:wireless}).
+  \item The maximum send rate of GameController return packets has been limited to \qty{2}{\per\second} (\cf~\cref{sec:wireless}).
   \item First kick-off and the goals attacked in the first half are determined by coin toss (\cf~\cref{sec:field_side_and_initial_kickoff}).
   \item The kick-off does not need to be indirect, neither for the attacking nor the defending team (\cf~\cref{sec:indirect_kick,sec:kick-off}).
   \item During kick-off, the number of players of the attacking team in the part of the center circle that is in the own half is not limited anymore (\cf~\cref{sec:kick-off}).

--- a/rules/robot_players.tex
+++ b/rules/robot_players.tex
@@ -115,6 +115,6 @@ Robots may only communicate on fields that are not running an official game or f
 
 The GameController will use UDP to connect to the robots. The source distribution of the GameController provides the header file \emph{RoboCupGameControlData.h} that defines all messages sent by the GameController to the robots. They correspond to the \emph{robot states} described in \cref{sec:robot_states}.
 
-Robots send status updates (defined in \emph{RoboCupGameControlData.h}) to the GameController. These return packets must be addressed directly to the GameController PC (\ie not broadcast) and sent on the GameController return UDP port specified by the symbol \verb!GAMECONTROLLER_RETURN_PORT! in \emph{RoboCupGameControlData.h}.
+Robots send status updates (defined in \emph{RoboCupGameControlData.h}) to the GameController. These return packets must be addressed directly to the GameController PC (\ie not broadcast) and sent on the GameController return UDP port specified by the symbol \verb!GAMECONTROLLER_RETURN_PORT! in \emph{RoboCupGameControlData.h}. The rate at which return packets may be sent is limited to \qty{2}{\per\second}.
 
 The use of remote processing/sensing is prohibited.


### PR DESCRIPTION
High rates blow up the size of GameController log files.