### PR TITLE
Revert sentence from 740673adcfe

### DIFF
--- a/rules/game_process.tex
+++ b/rules/game_process.tex
@@ -67,8 +67,9 @@ The primary states are:
   \centerline{\includegraphics[width=0.9\columnwidth]{figs/states_new.pdf}}
   \caption{Diagram of the robot states.
     \\\textbf{Chest button} transitions are shown as gray arrows.
-    However, any transition possible should be sent by the GameController.
     \\\textbf{GameController} transitions are shown as black arrows.
+    % The following sentence is necessary because the GameController can undo actions.
+    However, any transition possible can actually be sent by the GameController.
     \\Calibration transitions are shown as purple arrows which mean pressing the \textbf{front head button + the chest button}.
     \\From any state it can be transitioned to the \texttt{unstiff} state, shown as a blue arrow, via pressing all \textbf{three head buttons}.
     Pressing the \textbf{chest button} in the \texttt{unstiff} state allows a transition to the \texttt{initial} state, or a state as indicated by the GameController.}


### PR DESCRIPTION
The rewrite of this sentence in 2021 led teams to believe that transitions from finished to anything else can never happen, but they can due to the undo feature. This is exactly what the sentence was there for.