### PR TITLE
Add standby to the initial kickoff procedure

### DIFF
--- a/rules/game_process.tex
+++ b/rules/game_process.tex
@@ -231,6 +231,9 @@ Latest \qty{1}{\min} before the game starts all robots must be placed on the tou
 % If a team places robots themselves for initial kick-off, it is allowed for the team to vary the spacing and orientation of the robot positions along legal positions on their half's touchlines~(see also~\cref{sec:inside_outside}).
 
 Robots are brought into the \texttt{initial} state after they are placed.
+Once all robots have been placed and all human team members have left the field, the head referee officially starts or resumes the game by calling the beginning of the \texttt{standby} state.
+No further human intervention is allowed by the teams after this point.
+
 Once the robots receive the \texttt{ready} visual signal from the referee or the signal from the GameController, whichever happens first, they proceed as described in \cref{sec:kick-off}.
 
 % \begin{figure}[t!]


### PR DESCRIPTION
Another tiny pull request for clarification.

The reason for this is twofold:

- While reviewing the drop-ball rule, I momentarily blanked on whether a restart after a timeout has Standby or not;
- In general, I noticed that there is no mention of the Standby state in either kickoff procedure: it's currently only in the specification of the robot states.

So, this little addition aims to better position the Standby state within the flow of the game, and hopefully provide an easy-to-find answer for any random robocupper wondering the same thing as I just did.

This is based on the GameController implementation, which does have a Standby state after a timeout.